### PR TITLE
Remove KVO observer on deinit

### DIFF
--- a/LoadingPlaceholderView/LoadingPlaceholderView.swift
+++ b/LoadingPlaceholderView/LoadingPlaceholderView.swift
@@ -118,6 +118,10 @@ open class LoadingPlaceholderView: UIView {
     }
     
     deinit {
+		if let observer = viewToConverObservation {
+			observer.invalidate()
+			removeObserver(observer, forKeyPath: "bounds")
+		}
         viewToConverObservation = nil
     }
     


### PR DESCRIPTION
In my app using this placeholder view, I would occasionally receive the following crash about KVO observers not being removed when the view is deallocated:

```
Fatal Exception: NSInternalInconsistencyException
An instance 0x141287930 of class LoadingPlaceholderView.LoadingPlaceholderView was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x174426c80> ( <NSKeyValueObservance 0x1746459d0: Observer: 0x174a67540, Key path: bounds, Options: <New: NO, Old: NO, Prior: NO> Context: 0x0, Property: 0x174244320> )
```

Adding this code in the view's `deinit` seems to have fixed the issue. 