### PR TITLE
Revert "Remove KVO observer on deinit"

### DIFF
--- a/LoadingPlaceholderView/LoadingPlaceholderView.swift
+++ b/LoadingPlaceholderView/LoadingPlaceholderView.swift
@@ -118,10 +118,6 @@ open class LoadingPlaceholderView: UIView {
     }
     
     deinit {
-		if let observer = viewToConverObservation {
-			observer.invalidate()
-			removeObserver(observer, forKeyPath: "bounds")
-		}
         viewToConverObservation = nil
     }
     


### PR DESCRIPTION
Reverts MarioIannotta/LoadingPlaceholderView#1 
cause crash:
"Cannot remove an observer for the key path \"bounds\" from <Loading PlaceholderView.Loading PlaceholderView> because it is not registered as an observer."